### PR TITLE
udp: Add support for listen on an ephemeral port

### DIFF
--- a/runtime/net/transport.c
+++ b/runtime/net/transport.c
@@ -109,12 +109,16 @@ int trans_table_add_with_ephemeral_port(struct trans_entry *e)
 	uint16_t num_ephemeral = MAX_EPHEMERAL - MIN_EPHEMERAL + 1;
 	int ret;
 
-	if (e->match != TRANS_MATCH_5TUPLE)
-		return -EINVAL;
-
+	assert(e->match == TRANS_MATCH_3TUPLE ||
+	       e->match == TRANS_MATCH_5TUPLE);
 	e->laddr.port = 0;
-	offset = trans_hash_5tuple(e->proto, e->laddr, e->raddr) +
-							load_acquire(&ephemeral_offset);
+	if (e->match == TRANS_MATCH_3TUPLE)
+	    offset = trans_hash_3tuple(e->proto, e->laddr) + 
+            load_acquire(&ephemeral_offset);
+	else
+	    offset = trans_hash_5tuple(e->proto, e->laddr, e->raddr) + 
+            load_acquire(&ephemeral_offset);
+
 	while (next_ephemeral < num_ephemeral) {
 		uint32_t port = MIN_EPHEMERAL +
 				(next_ephemeral++ + offset) % num_ephemeral;

--- a/runtime/net/udp.c
+++ b/runtime/net/udp.c
@@ -219,7 +219,10 @@ int udp_listen(struct netaddr laddr, udpconn_t **c_out)
 	udp_init_conn(c);
 	trans_init_3tuple(&c->e, IPPROTO_UDP, &udp_conn_ops, laddr);
 
-	ret = trans_table_add(&c->e);
+	if (laddr.port == 0)
+		ret = trans_table_add_with_ephemeral_port(&c->e);
+	else
+		ret = trans_table_add(&c->e);
 	if (ret) {
 		sfree(c);
 		return ret;


### PR DESCRIPTION
Currently, creating a client with an ephemeral port requires calling dial_udp and a 5-tuple match, which is incompatible with communicating with multiple endpoints.
This PR adds support for using an ephemeral port with udp_listen().