### PR TITLE
Remove spin dependency for synthetic app

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Shenango Developers"]
 
 [dependencies]
 libc = "0.2"
-spin = "0.4.9"
 byteorder = "1.2.1"
 
 [build-dependencies]


### PR DESCRIPTION
This fixes the `cargo build --release` failure while trying to build the synthetic app (one of steps mentioned in the README):

```
saubhik@node-0:~/bw_artif/shenango/apps/synthetic$ cargo build --release
   Compiling spin v0.4.10
   Compiling clang-sys v0.21.2
   Compiling quote v0.4.2
   Compiling aho-corasick v0.6.10
   Compiling memchr v1.0.2
   Compiling atty v0.2.14
   Compiling log v0.3.9
   Compiling which v1.0.5
   Compiling rand v0.4.6
   Compiling hostname v0.1.5
   Compiling net2 v0.2.37
   Compiling bindgen v0.32.3
   Compiling clap v2.33.3
   Compiling lockstep v0.1.0 (https://github.com/fintelia/lockstep.git?rev=9be97f6ef9d75b1a28a79734df238c08b4de7013#9be97f6e)
error[E0557]: feature has been removed
 --> /users/saubhik/.cargo/registry/src/github.com-1ecc6299db9ec823/spin-0.4.10/src/lib.rs:6:43
  |
6 | #![cfg_attr(feature = "const_fn", feature(const_fn))]
  |                                           ^^^^^^^^ feature has been removed
  |
  = note: split into finer-grained feature gates

   Compiling nom v3.2.1
For more information about this error, try `rustc --explain E0557`.
error: could not compile `spin` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```

With this update, the build works fine.