### PR TITLE
dpdk: Support GCC 10 and custom configuration

### DIFF
--- a/build/dpdk_19_11.patch
+++ b/build/dpdk_19_11.patch
@@ -1,0 +1,41 @@
+From ef934a648ed42e0bed0b28ca850f6c37c86ced69 Mon Sep 17 00:00:00 2001
+From: Tom Barbette <tom.barbette@uclouvain.be>
+Date: Fri, 1 Oct 2021 08:54:30 +0200
+Subject: [PATCH] Backport GCC 10 patches
+
+This is needed to compile on recent arch
+---
+ config/meson.build           | 4 +++-
+ mk/toolchain/gcc/rte.vars.mk | 2 ++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/config/meson.build b/config/meson.build
+index 364a8d7394..b6ff7d2525 100644
+--- a/config/meson.build
++++ b/config/meson.build
+@@ -181,7 +181,9 @@ warning_flags = [
+	# globally disabled warnings
+	'-Wno-address-of-packed-member',
+	'-Wno-packed-not-aligned',
+-	'-Wno-missing-field-initializers'
++	'-Wno-missing-field-initializers',
++	'-Wno-stringop-overflow'
++
+ ]
+ if not dpdk_conf.get('RTE_ARCH_64')
+ # for 32-bit, don't warn about casting a 32-bit pointer to 64-bit int - it's fine!!
+diff --git a/mk/toolchain/gcc/rte.vars.mk b/mk/toolchain/gcc/rte.vars.mk
+index 9fc704193b..fdf1678545 100644
+--- a/mk/toolchain/gcc/rte.vars.mk
++++ b/mk/toolchain/gcc/rte.vars.mk
+@@ -101,6 +101,8 @@ endif
+
+ # disable packed member unalign warnings
+ WERROR_FLAGS += -Wno-address-of-packed-member
++WERROR_FLAGS += -Wno-stringop-overflow
++WERROR_FLAGS += -Wno-zero-length-bounds
+
+ export CC AS AR LD OBJCOPY OBJDUMP STRIP READELF
+ export TOOLCHAIN_CFLAGS TOOLCHAIN_LDFLAGS TOOLCHAIN_ASFLAGS
+--
+2.25.1

--- a/build/init_submodules.sh
+++ b/build/init_submodules.sh
@@ -16,6 +16,7 @@ cd ..
 
 echo building DPDK
 patch -p 1 -d dpdk/ < build/ixgbe_19_11.patch
+patch -p 1 -d dpdk/ < build/dpdk_19_11.patch
 if lspci | grep -q 'ConnectX-[4,5]'; then
   rm -f dpdk/drivers/net/mlx5/mlx5_custom.h
   patch -p1 -N -d dpdk/ < build/mlx5_19_11.patch
@@ -29,6 +30,9 @@ elif lspci | grep -q 'ConnectX-3'; then
   patch -p1 -N -d dpdk/ < build/mlx4_19_11.patch
 fi
 make -C dpdk/ config T=x86_64-native-linuxapp-gcc
+if [ -e build/dpdk.config ] ; then
+	cp build/dpdk.config dpdk/build/.config
+fi
 make -C dpdk/ -j $CORES
 
 export EXTRA_CFLAGS=


### PR DESCRIPTION
GCC 10 is needed for recent archs, because DPDK will take the latest -mtune, so I applied the two concerned patches from upstream on 19.11. It's only false positives -Werror actually.

Also, as I have linking problem, and KNI does not compile in DPDK 19.11 with recent kernel, I propose a way to pass a custom .config file to DPDK. Just putting it in build/dpdk.config and it will be used instead of the default generated .config.