### PR TITLE
Changing deprecated llvm_asm usage to asm

### DIFF
--- a/bindings/rust/src/asm.rs
+++ b/bindings/rust/src/asm.rs
@@ -1,16 +1,18 @@
+use std::arch::asm;
+
 #[inline]
 pub fn cpu_relax() {
-    unsafe { llvm_asm!("pause" :::: "volatile") }
+    unsafe { asm!("pause", options(att_syntax)) };
 }
 #[inline]
 pub fn cpu_serialize() {
-    unsafe { llvm_asm!("cpuid" : : : "rax", "rbx", "rcx", "rdx": "volatile") }
+    unsafe { asm!("cpuid", out("rax") _, out("rcx") _, out("rdx")_, options(att_syntax)) };
 }
 #[inline]
 pub fn rdtsc() -> u64 {
     let a: u32;
     let d: u32;
-    unsafe { llvm_asm!("rdtsc" : "={eax}"(a), "={edx}"(d) : : : "volatile" ) };
+    unsafe { asm!("rdtsc", out("eax") a, out("edx") d, options(att_syntax)) };
     (a as u64) | ((d as u64) << 32)
 }
 #[inline]
@@ -18,7 +20,6 @@ pub fn rdtscp() -> (u64, u32) {
     let a: u32;
     let d: u32;
     let c: u32;
-    unsafe { llvm_asm!("rdtscp" : "={eax}"(a), "={edx}"(d), "={ecx}"(c) : : : "volatile") };
-
+    unsafe { asm!("rdtscp", out("eax") a, out("edx") d, out("ecx") c, options(att_syntax)) };
     ((a as u64) | ((d as u64) << 32), c)
 }


### PR DESCRIPTION
The `llvm_asm` package is deprecated (more info [here](https://blog.rust-lang.org/inside-rust/2020/06/08/new-inline-asm.html)) in favor of `asm` ([docs](https://doc.rust-lang.org/unstable-book/library-features/asm.html)).
This PR updates the relevant calls to `llvm_asm` to use the new `asm` package instead.

One thing to note is, now the default syntax is not AT&T; it's Intel. Therefore all usage of `asm` now explicitly passes `options(att_syntax)` to keep the same functionality as before.