### PR TITLE
Add rust bindings for various features

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -34,3 +34,7 @@ path = "src/test_poll.rs"
 [[bin]]
 name = "udp"
 path = "src/test_udp.rs"
+
+[[bin]]
+name = "mutex"
+path = "src/test_mutex.rs"

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -30,3 +30,7 @@ path = "src/test_smalloc.rs"
 [[bin]]
 name = "poll"
 path = "src/test_poll.rs"
+
+[[bin]]
+name = "udp"
+path = "src/test_udp.rs"

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -42,3 +42,7 @@ path = "src/test_mutex.rs"
 [[bin]]
 name = "condvar"
 path = "src/test_condvar.rs"
+
+[[bin]]
+name = "timer"
+path = "src/test_timer.rs"

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -38,3 +38,7 @@ path = "src/test_udp.rs"
 [[bin]]
 name = "mutex"
 path = "src/test_mutex.rs"
+
+[[bin]]
+name = "condvar"
+path = "src/test_condvar.rs"

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -26,3 +26,7 @@ path = "src/test_hello.rs"
 [[bin]]
 name = "smalloc"
 path = "src/test_smalloc.rs"
+
+[[bin]]
+name = "poll"
+path = "src/test_poll.rs"

--- a/bindings/rust/shenango.h
+++ b/bindings/rust/shenango.h
@@ -13,6 +13,7 @@
 #include <runtime/smalloc.h>
 #include <runtime/storage.h>
 #include <runtime/sync.h>
+#include <runtime/poll.h>
 #include <runtime/tcp.h>
 #include <runtime/thread.h>
 #include <runtime/timer.h>

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -19,6 +19,7 @@ mod asm;
 pub mod poll;
 pub mod storage;
 pub mod sync;
+pub mod time;
 // preserve import paths.
 pub use sync::{SpinLock, WaitGroup};
 pub mod tcp;

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -7,14 +7,8 @@
 #![feature(new_uninit)]
 #![feature(get_mut_unchecked)]
 
-extern crate byteorder;
-
-use std::cell::UnsafeCell;
 use std::ffi::CString;
-use std::mem;
 use std::os::raw::{c_int, c_void};
-use std::sync::atomic::{AtomicI32, Ordering};
-use std::sync::Arc;
 use std::time::Duration;
 
 pub mod ffi {
@@ -24,6 +18,9 @@ pub mod ffi {
 mod asm;
 pub mod poll;
 pub mod storage;
+pub mod sync;
+// preserve import paths.
+pub use sync::{SpinLock, WaitGroup};
 pub mod tcp;
 pub mod thread;
 pub mod udp;
@@ -94,100 +91,4 @@ where
             Box::into_raw(Box::new(f)) as *mut c_void,
         )
     })
-}
-
-#[derive(Clone)]
-pub struct WaitGroup {
-    inner: Arc<ffi::waitgroup>,
-}
-impl WaitGroup {
-    pub fn new() -> Self {
-        let mut inner_uninit = Arc::new_uninit();
-        unsafe { ffi::waitgroup_init(Arc::get_mut_unchecked(&mut inner_uninit).as_mut_ptr()) };
-        let inner = unsafe { inner_uninit.assume_init() };
-        Self { inner }
-    }
-    pub fn add(&self, count: i32) {
-        unsafe { ffi::waitgroup_add(&*self.inner as *const _ as *mut _, count as c_int) }
-    }
-    pub fn wait(&self) {
-        unsafe { ffi::waitgroup_wait(&*self.inner as *const _ as *mut _) }
-    }
-    pub fn done(&self) {
-        self.add(-1)
-    }
-}
-unsafe impl Send for WaitGroup {}
-unsafe impl Sync for WaitGroup {}
-
-pub struct SpinLock {
-    inner: UnsafeCell<ffi::spinlock_t>,
-}
-impl SpinLock {
-    pub fn new() -> Self {
-        Self {
-            inner: UnsafeCell::new(ffi::spinlock_t { locked: 0 }),
-        }
-    }
-
-    #[inline]
-    unsafe fn as_atomic(&self) -> &mut AtomicI32 {
-        mem::transmute(&mut (*self.inner.get()).locked)
-    }
-
-    #[inline]
-    fn as_raw(&self) -> *mut ffi::spinlock_t {
-        self.inner.get()
-    }
-
-    #[inline]
-    pub fn lock_np(&self) {
-        preempt_disable();
-        self.lock();
-    }
-
-    #[inline]
-    pub fn unlock_np(&self) {
-        self.unlock();
-        preempt_enable();
-    }
-
-    #[inline]
-    pub fn lock(&self) {
-        let inner = unsafe { self.as_atomic() };
-        while inner.swap(1, Ordering::Acquire) != 0 {
-            while inner.load(Ordering::Relaxed) != 0 {
-                cpu_relax();
-            }
-        }
-    }
-
-    #[inline]
-    pub fn try_lock(&self) -> bool {
-        let inner = unsafe { self.as_atomic() };
-        inner.swap(1, Ordering::Acquire) == 0
-    }
-
-    #[inline]
-    pub fn unlock(&self) {
-        let inner = unsafe { self.as_atomic() };
-        assert_eq!(inner.swap(0, Ordering::Release), 1);
-    }
-}
-unsafe impl Send for SpinLock {}
-unsafe impl Sync for SpinLock {}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn spinlock() {
-        let lock = SpinLock::new();
-
-        lock.lock();
-        assert!(!lock.try_lock());
-        lock.unlock();
-        assert!(lock.try_lock());
-    }
 }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -22,6 +22,7 @@ pub mod ffi {
 }
 
 mod asm;
+pub mod poll;
 pub mod storage;
 pub mod tcp;
 pub mod thread;

--- a/bindings/rust/src/poll.rs
+++ b/bindings/rust/src/poll.rs
@@ -1,0 +1,114 @@
+use crate::ffi::{poll_arm, poll_init, poll_trigger, poll_trigger_t, poll_wait, poll_waiter_t};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+pub struct PollWaiter {
+    inner: Arc<poll_waiter_t>,
+    active_triggers: Vec<Option<(Arc<poll_trigger_t>, u32)>>,
+    empty_slots: Vec<usize>,
+    done: Arc<AtomicBool>,
+}
+
+unsafe impl Send for PollWaiter {}
+unsafe impl Sync for PollWaiter {}
+
+impl PollWaiter {
+    pub fn new() -> Self {
+        let mut poll = Arc::new_uninit();
+        let inner = unsafe {
+            poll_init(Arc::get_mut_unchecked(&mut poll).as_mut_ptr());
+            poll.assume_init()
+        };
+
+        PollWaiter {
+            inner,
+            active_triggers: Default::default(),
+            empty_slots: Default::default(),
+            done: Default::default(),
+        }
+    }
+
+    fn get_slot(&mut self) -> usize {
+        self.empty_slots.pop().unwrap_or(self.active_triggers.len())
+    }
+
+    pub fn trigger(&mut self, data: u32) -> PollTrigger {
+        let idx = self.get_slot();
+        let trigger = unsafe {
+            let trigger = Arc::new_zeroed().assume_init();
+            poll_arm(
+                &*self.inner as *const _ as *mut _,
+                &*trigger as *const _ as *mut _,
+                idx as _,
+            );
+            trigger
+        };
+
+        // because triggers happen via drop, we need to ensure that their memory is not freed
+        // before wait() can access it.
+        if idx >= self.active_triggers.len() {
+            self.active_triggers
+                .push(Some((Arc::clone(&trigger), data)));
+        } else {
+            self.active_triggers[idx] = Some((Arc::clone(&trigger), data));
+        }
+
+        PollTrigger {
+            inner: trigger,
+            waiter: Arc::clone(&self.inner),
+            waiter_done: Arc::clone(&self.done),
+        }
+    }
+
+    pub fn wait(&mut self) -> u32 {
+        let idx = unsafe { poll_wait(&*self.inner as *const _ as *mut _) as _ };
+        assert!(
+            idx < self.active_triggers.len(),
+            "poll_wait returned bad index"
+        );
+
+        let ent: &mut Option<_> = &mut self.active_triggers[idx];
+        match ent.take() {
+            Some((_, v)) => {
+                // the trigger object, _, will get dropped now.
+                self.empty_slots.push(idx);
+                v
+            }
+            None => {
+                panic!("poll_wait returned index to empty trigger slot");
+            }
+        }
+    }
+}
+
+impl Drop for PollWaiter {
+    fn drop(&mut self) {
+        self.done.store(true, Ordering::SeqCst);
+    }
+}
+
+pub struct PollTrigger {
+    inner: Arc<poll_trigger_t>,
+    waiter: Arc<poll_waiter_t>,
+    waiter_done: Arc<AtomicBool>,
+}
+
+unsafe impl Send for PollTrigger {}
+unsafe impl Sync for PollTrigger {}
+
+impl Drop for PollTrigger {
+    fn drop(&mut self) {
+        if self.waiter_done.load(Ordering::SeqCst) {
+            return;
+        }
+
+        unsafe {
+            poll_trigger(
+                &*self.waiter as *const _ as *mut _,
+                &*self.inner as *const _ as *mut _,
+            );
+        }
+    }
+}

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -1,0 +1,122 @@
+//! Sync facilities.
+
+use crate::{cpu_relax, ffi, preempt_disable, preempt_enable};
+use std::cell::UnsafeCell;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+use std::os::raw::c_int;
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct WaitGroup {
+    inner: Arc<ffi::waitgroup>,
+}
+
+impl WaitGroup {
+    pub fn new() -> Self {
+        let mut inner_uninit = Arc::new_uninit();
+        unsafe { ffi::waitgroup_init(Arc::get_mut_unchecked(&mut inner_uninit).as_mut_ptr()) };
+        let inner = unsafe { inner_uninit.assume_init() };
+        Self { inner }
+    }
+    pub fn add(&self, count: i32) {
+        unsafe { ffi::waitgroup_add(&*self.inner as *const _ as *mut _, count as c_int) }
+    }
+    pub fn wait(&self) {
+        unsafe { ffi::waitgroup_wait(&*self.inner as *const _ as *mut _) }
+    }
+    pub fn done(&self) {
+        self.add(-1)
+    }
+}
+
+impl Default for WaitGroup {
+    fn default() -> Self {
+        WaitGroup::new()
+    }
+}
+
+unsafe impl Send for WaitGroup {}
+unsafe impl Sync for WaitGroup {}
+
+pub struct SpinLock {
+    inner: UnsafeCell<ffi::spinlock_t>,
+}
+
+impl SpinLock {
+    pub fn new() -> Self {
+        Self {
+            inner: UnsafeCell::new(ffi::spinlock_t { locked: 0 }),
+        }
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    #[inline]
+    unsafe fn as_atomic(&self) -> &mut AtomicI32 {
+        mem::transmute(&mut (*self.inner.get()).locked)
+    }
+
+    #[inline]
+    pub fn as_raw(&self) -> *mut ffi::spinlock_t {
+        self.inner.get()
+    }
+
+    #[inline]
+    pub fn lock_np(&self) {
+        preempt_disable();
+        self.lock();
+    }
+
+    #[inline]
+    pub fn unlock_np(&self) {
+        self.unlock();
+        preempt_enable();
+    }
+
+    #[inline]
+    pub fn lock(&self) {
+        let inner = unsafe { self.as_atomic() };
+        while inner.swap(1, Ordering::Acquire) != 0 {
+            while inner.load(Ordering::Relaxed) != 0 {
+                cpu_relax();
+            }
+        }
+    }
+
+    #[inline]
+    pub fn try_lock(&self) -> bool {
+        let inner = unsafe { self.as_atomic() };
+        inner.swap(1, Ordering::Acquire) == 0
+    }
+
+    #[inline]
+    pub fn unlock(&self) {
+        let inner = unsafe { self.as_atomic() };
+        assert_eq!(inner.swap(0, Ordering::Release), 1);
+    }
+}
+
+impl Default for SpinLock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+unsafe impl Send for SpinLock {}
+unsafe impl Sync for SpinLock {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spinlock() {
+        let lock = SpinLock::new();
+
+        lock.lock();
+        assert!(!lock.try_lock());
+        lock.unlock();
+        assert!(lock.try_lock());
+    }
+}

--- a/bindings/rust/src/test_condvar.rs
+++ b/bindings/rust/src/test_condvar.rs
@@ -1,0 +1,50 @@
+use shenango::sync::{Condvar, Mutex};
+
+const NUM: u32 = 20;
+
+fn sender(m: Mutex<Vec<u32>>, cv: Condvar) {
+    shenango::thread::spawn_detached(move || {
+        for i in 0..NUM {
+            shenango::sleep(std::time::Duration::from_millis(10));
+            println!("pushing {:?}", i);
+            m.lock().push(i);
+            cv.signal();
+        }
+    });
+}
+
+fn main_handler() {
+    println!("starting");
+
+    let mux = Mutex::new(Vec::new());
+    let cv = Condvar::new();
+
+    sender(mux.clone(), cv.clone());
+
+    let mut expected = 0;
+    let start = shenango::microtime();
+    loop {
+        let mut g = cv.wait(&mux);
+        match g.pop() {
+            Some(i) if i == expected => {
+                println!("rcvd, elapsed = {:?}", shenango::microtime() - start);
+                expected += 1;
+            }
+            e => {
+                println!("err: {:?}", e);
+            }
+        }
+
+        if expected == NUM {
+            break;
+        }
+    }
+
+    println!("done");
+}
+
+fn main() {
+    let args: Vec<_> = ::std::env::args().collect();
+    assert!(args.len() >= 2, "arg must be config file");
+    shenango::runtime_init(args[1].clone(), main_handler).unwrap();
+}

--- a/bindings/rust/src/test_mutex.rs
+++ b/bindings/rust/src/test_mutex.rs
@@ -1,0 +1,53 @@
+use shenango::sync::Mutex;
+
+fn mutex_one(m: Mutex<u32>, start: u64) {
+    shenango::thread::spawn_detached(move || {
+        println!("{:?} lock 1", shenango::microtime() - start);
+        let mut g = m.lock();
+        println!("{:?} locked 1", shenango::microtime() - start);
+        *g = 1;
+        shenango::sleep(std::time::Duration::from_millis(100));
+        println!("{:?} 1 done", shenango::microtime() - start);
+    });
+}
+
+fn mutex_two(m: Mutex<u32>, start: u64) {
+    shenango::thread::spawn_detached(move || {
+        shenango::sleep(std::time::Duration::from_millis(50));
+        println!("{:?} lock 2", shenango::microtime() - start);
+        let mut g = m.lock();
+        println!("{:?} locked 2", shenango::microtime() - start);
+        *g = 2;
+        shenango::sleep(std::time::Duration::from_millis(100));
+        println!("{:?} 2 done", shenango::microtime() - start);
+    });
+}
+
+fn main_handler() {
+    let start = shenango::microtime();
+    println!("making mutex");
+
+    //let mux = Arc::new(Mutex::new());
+    let mux = Mutex::new(0);
+
+    println!("start");
+    mutex_one(mux.clone(), start);
+    mutex_two(mux.clone(), start);
+
+    shenango::sleep(std::time::Duration::from_millis(10));
+    assert!(mux.try_lock().is_err());
+    println!("{:?} try lock ok", shenango::microtime() - start);
+
+    shenango::sleep(std::time::Duration::from_millis(100));
+    println!("{:?} try read", shenango::microtime() - start);
+    let v = { *mux.lock() };
+    println!("{:?} read {:?}", shenango::microtime() - start, v);
+    assert_eq!(v, 2);
+    println!("done");
+}
+
+fn main() {
+    let args: Vec<_> = ::std::env::args().collect();
+    assert!(args.len() >= 2, "arg must be config file");
+    shenango::runtime_init(args[1].clone(), main_handler).unwrap();
+}

--- a/bindings/rust/src/test_poll.rs
+++ b/bindings/rust/src/test_poll.rs
@@ -1,0 +1,54 @@
+use shenango::poll::{PollTrigger, PollWaiter};
+
+fn short(t: PollTrigger) {
+    shenango::thread::spawn_detached(move || {
+        let _t = t;
+        shenango::sleep(std::time::Duration::from_millis(10));
+    });
+}
+
+fn long(t: PollTrigger) {
+    shenango::thread::spawn_detached(move || {
+        let _t = t;
+        shenango::sleep(std::time::Duration::from_millis(50));
+    });
+}
+
+fn main_handler() {
+    println!("making poller");
+
+    let mut poll = PollWaiter::new();
+    let short_trigger = poll.trigger(17);
+    let long_trigger = poll.trigger(42);
+
+    short(short_trigger);
+    long(long_trigger);
+
+    let mut short_count = 0;
+    let mut long_count = 0;
+    let start = shenango::microtime();
+    while shenango::microtime() - start < 1_000_000 {
+        match poll.wait() {
+            17 => {
+                short_count += 1;
+                let short_trigger = poll.trigger(17);
+                short(short_trigger);
+            }
+            42 => {
+                long_count += 1;
+                let long_trigger = poll.trigger(42);
+                long(long_trigger);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    assert!(short_count >= (long_count * 5 - 2));
+    println!("short {:?} long {:?} done", short_count, long_count);
+}
+
+fn main() {
+    let args: Vec<_> = ::std::env::args().collect();
+    assert!(args.len() >= 2, "arg must be config file");
+    shenango::runtime_init(args[1].clone(), main_handler).unwrap();
+}

--- a/bindings/rust/src/test_timer.rs
+++ b/bindings/rust/src/test_timer.rs
@@ -1,0 +1,38 @@
+use shenango::sync::WaitGroup;
+use shenango::time::Timer;
+use std::time::Duration;
+
+fn sleep(t: Timer, wg: WaitGroup) {
+    wg.add(1);
+    shenango::thread::spawn_detached(move || {
+        let then = shenango::microtime();
+        t.sleep(Duration::from_millis(100));
+        println!("woke up after {:?} us", shenango::microtime() - then);
+        wg.done();
+    });
+}
+
+fn main_handler() {
+    println!("starting");
+
+    println!("test immediate cancel");
+    let t = Timer::new();
+    t.cancel();
+
+    let wg = WaitGroup::new();
+    let t = Timer::new();
+    sleep(t.clone(), wg.clone());
+
+    let start = shenango::microtime();
+    Timer::new().sleep(Duration::from_millis(10));
+    println!("slept for {:?} us", shenango::microtime() - start);
+    t.cancel();
+    wg.wait();
+    println!("done after {:?} us", shenango::microtime() - start);
+}
+
+fn main() {
+    let args: Vec<_> = ::std::env::args().collect();
+    assert!(args.len() >= 2, "arg must be config file");
+    shenango::runtime_init(args[1].clone(), main_handler).unwrap();
+}

--- a/bindings/rust/src/test_udp.rs
+++ b/bindings/rust/src/test_udp.rs
@@ -1,0 +1,52 @@
+use shenango::sync::WaitGroup;
+use shenango::udp::{udp_accept, UdpConnection};
+use std::net::{Ipv4Addr, SocketAddrV4};
+
+fn looper(t: UdpConnection) {
+    println!("new conn: {:?}", t.remote_addr());
+    let mut buf = [0u8; 128];
+    loop {
+        let len = t.recv(&mut buf).unwrap();
+        t.send(&buf[..len]).unwrap();
+    }
+}
+
+fn client(addr: SocketAddrV4, i: u16, wg: WaitGroup) {
+    println!("starting client {:?}", i,);
+    let cn = UdpConnection::dial(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 5151 + i), addr).unwrap();
+    println!("{:?} -> {:?}", cn.local_addr(), cn.remote_addr());
+    let mut buf = [0u8; 8];
+    for i in 0..5 {
+        let snd = [i; 8];
+        cn.send(&snd).unwrap();
+        let l = cn.recv(&mut buf).unwrap();
+        assert_eq!(&buf[..l], &snd);
+    }
+
+    println!("client {:?} done", i);
+    wg.done();
+}
+
+fn main_handler() {
+    shenango::thread::spawn(move || {
+        println!("starting spawner");
+        udp_accept(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 5151), looper).unwrap();
+    });
+
+    let wg = WaitGroup::new();
+    for i in 1..6 {
+        let wg = wg.clone();
+        wg.add(1);
+        shenango::sleep(std::time::Duration::from_millis(1));
+        shenango::thread::spawn(move || client("10.1.1.2:5151".parse().unwrap(), i, wg));
+    }
+
+    wg.wait();
+    println!("done");
+}
+
+fn main() {
+    let args: Vec<_> = ::std::env::args().collect();
+    assert!(args.len() >= 2, "arg must be config file");
+    shenango::runtime_init(args[1].clone(), main_handler).unwrap();
+}

--- a/bindings/rust/src/time.rs
+++ b/bindings/rust/src/time.rs
@@ -1,0 +1,68 @@
+use crate::ffi::{self, timer_entry};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration;
+
+pub struct Timer {
+    inner: Arc<timer_entry>,
+    done: Arc<AtomicBool>,
+}
+
+unsafe impl Send for Timer {}
+unsafe impl Sync for Timer {}
+
+impl Clone for Timer {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            done: Default::default(),
+        }
+    }
+}
+
+impl Timer {
+    pub fn new() -> Self {
+        let mut entry = Arc::new_uninit();
+        let inner = unsafe {
+            ffi::timer_sleep_init(Arc::get_mut_unchecked(&mut entry).as_mut_ptr());
+            entry.assume_init()
+        };
+
+        Self {
+            inner,
+            done: Default::default(),
+        }
+    }
+
+    pub fn sleep(self, dur: Duration) {
+        if self.done.load(Ordering::SeqCst) {
+            return;
+        }
+
+        unsafe { ffi::timer_sleep_wait(&*self.inner as *const _ as *mut _, dur.as_micros() as _) };
+        self.done.store(true, Ordering::SeqCst);
+    }
+
+    pub fn cancel(self) {
+        match self
+            .done
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        {
+            Ok(false) => {
+                unsafe { ffi::timer_sleep_cancel(&*self.inner as *const _ as *mut _) };
+            }
+            Err(true) => {
+                return;
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub fn sleep(duration: Duration) {
+    unsafe {
+        ffi::timer_sleep(duration.as_secs() * 1_000_000 + duration.subsec_nanos() as u64 / 1000)
+    }
+}

--- a/bindings/rust/src/udp.rs
+++ b/bindings/rust/src/udp.rs
@@ -14,6 +14,7 @@ fn isize_to_result(i: isize) -> io::Result<usize> {
     }
 }
 
+#[derive(Clone)]
 pub struct UdpConnection(*mut ffi::udpconn_t);
 impl UdpConnection {
     pub fn dial(local_addr: SocketAddrV4, remote_addr: SocketAddrV4) -> io::Result<Self> {

--- a/inc/runtime/sync.h
+++ b/inc/runtime/sync.h
@@ -80,6 +80,12 @@ static inline void assert_mutex_held(mutex_t *m)
 }
 
 
+extern bool mutex_try_lock_(mutex_t *m);
+extern void mutex_lock_(mutex_t *m);
+extern void mutex_unlock_(mutex_t *m);
+extern bool mutex_held_(mutex_t *m);
+extern void assert_mutex_held_(mutex_t *m);
+
 /*
  * Condition variable support
  */

--- a/inc/runtime/timer.h
+++ b/inc/runtime/timer.h
@@ -40,6 +40,14 @@ timer_init(struct timer_entry *e, timer_fn_t fn, unsigned long arg)
 extern void timer_start(struct timer_entry *e, uint64_t deadline_us);
 extern bool timer_cancel(struct timer_entry *e);
 
+/**
+ * timer_sleep_init - initializes a timer that wakes the thread that calls this function.
+ * @e: timer entry to initialize. This entry can later be passed to timer_sleep_wait to perform the sleep (MUST be called from the same thread)
+ * or timer_sleep_cancel to cancel the sleep and wake the thread immediately.
+ */
+extern void timer_sleep_init(struct timer_entry *e);
+extern void timer_sleep_wait(struct timer_entry *e, uint64_t duration_us);
+extern void timer_sleep_cancel(struct timer_entry *e);
 
 /*
  * High-level API

--- a/inc/runtime/udp.h
+++ b/inc/runtime/udp.h
@@ -94,3 +94,8 @@ static inline ssize_t udp_respondv(const struct iovec *iov, int iovcnt,
 {
 	return udp_sendv(iov, iovcnt, d->laddr, d->raddr);
 }
+
+struct udp_conn_spawner;
+typedef struct udp_conn_spawner udpconnspawn_t;
+int udp_conn_listen(struct netaddr laddr, int backlog, udpconnspawn_t **c_out);
+int udp_accept(udpconnspawn_t *q, udpconn_t **c_out);

--- a/runtime/net/udp.c
+++ b/runtime/net/udp.c
@@ -703,6 +703,8 @@ static void udp_conn_queue_recv(struct trans_entry *e, struct mbuf *m)
 	spin_unlock_np(&q->l);
 	waitq_signal_finish(th);
 
+    return;
+
 done:
 	mbuf_free(m);
 }

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -62,6 +62,52 @@ void mutex_init(mutex_t *m)
 	list_head_init(&m->waiters);
 }
 
+/**
+ * mutex_try_lock - attempts to acquire a mutex
+ * @m: the mutex to acquire
+ *
+ * Returns true if the acquire was successful.
+ */
+bool mutex_try_lock_(mutex_t *m)
+{
+	return mutex_try_lock(m);
+}
+
+/**
+ * mutex_lock - acquires a mutex
+ * @m: the mutex to acquire
+ */
+void mutex_lock_(mutex_t *m)
+{
+	mutex_lock(m);
+}
+
+/**
+ * mutex_unlock - releases a mutex
+ * @m: the mutex to release
+ */
+void mutex_unlock_(mutex_t *m)
+{
+    mutex_unlock(m);
+}
+/**
+ * mutex_held - is the mutex currently held?
+ * @m: the mutex to check
+ */
+bool mutex_held_(mutex_t *m)
+{
+	return mutex_held(m);
+}
+
+/**
+ * assert_mutex_held - asserts that a mutex is currently held
+ * @m: the mutex that must be held
+ */
+void assert_mutex_held_(mutex_t *m)
+{
+	assert_mutex_held(m);
+}
+
 /*
  * Read-write mutex support
  */

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -15,7 +15,7 @@ test_runtime_rcu
 test_runtime_timer
 test_smalloc
 test_thread
-test_udp_echo
+test_udp
 test_storage
 test_storage_iops
 netperf

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -17,6 +17,7 @@ test_smalloc
 test_thread
 test_udp
 test_poll
+test_mutex
 test_storage
 test_storage_iops
 netperf

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -16,6 +16,7 @@ test_runtime_timer
 test_smalloc
 test_thread
 test_udp
+test_poll
 test_storage
 test_storage_iops
 netperf

--- a/tests/test_mutex.c
+++ b/tests/test_mutex.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+
+#include <base/stddef.h>
+#include <base/log.h>
+#include <base/time.h>
+#include <runtime/runtime.h>
+#include <runtime/sync.h>
+#include <runtime/timer.h>
+
+mutex_t m;
+uint64_t start;
+static void mutex_one(void *v) {
+    mutex_t *t = (mutex_t*) v;
+    mutex_lock(t);
+    printf("[%lu] locked one\n", microtime() - start);
+    timer_sleep(100);
+    mutex_unlock(t);
+    printf("[%lu] unlocked one\n", microtime() - start);
+}
+
+static void main_handler(void *arg)
+{
+    start = microtime();
+    mutex_init(&m);
+
+    thread_spawn(&mutex_one, (void*) &m);
+    timer_sleep(10);
+    if (mutex_try_lock(&m)) {
+        printf("try lock should not work\n");
+    } else {
+        printf("[%lu] try lock ok\n", microtime() - start);
+    }
+
+    mutex_lock(&m);
+    printf("[%lu] done\n", microtime() - start);
+    mutex_unlock(&m);
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	if (argc < 2) {
+		printf("arg must be config file\n");
+		return -EINVAL;
+	}
+
+	ret = runtime_init(argv[1], main_handler, NULL);
+	if (ret) {
+		printf("failed to start runtime\n");
+		return ret;
+	}
+
+	return 0;
+}

--- a/tests/test_poll.c
+++ b/tests/test_poll.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+
+#include <base/stddef.h>
+#include <base/log.h>
+#include <base/time.h>
+#include <runtime/runtime.h>
+#include <runtime/sync.h>
+#include <runtime/poll.h>
+#include <runtime/timer.h>
+
+
+static void short_work(void *v) {
+    poll_trigger_t *t = (poll_trigger_t*) v;
+    timer_sleep(100);
+    poll_trigger(t->waiter, t);
+}
+
+static void long_work(void *v) {
+    poll_trigger_t *t = (poll_trigger_t*) v;
+    timer_sleep(1000);
+    poll_trigger(t->waiter, t);
+}
+
+static void main_handler(void *arg)
+{
+    poll_waiter_t w;
+    poll_init(&w);
+
+    poll_trigger_t short_trigger;
+    poll_trigger_init(&short_trigger);
+    poll_arm(&w, &short_trigger, 1);
+
+    poll_trigger_t long_trigger;
+    poll_trigger_init(&long_trigger);
+    poll_arm(&w, &long_trigger, 0);
+
+    thread_spawn(&short_work, (void*) &short_trigger);
+    thread_spawn(&long_work, (void*) &long_trigger);
+
+    unsigned long res = poll_wait(&w);
+    if (res) {
+        printf("ok\n");
+    } else {
+        printf("error\n");
+    }
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	if (argc < 2) {
+		printf("arg must be config file\n");
+		return -EINVAL;
+	}
+
+	ret = runtime_init(argv[1], main_handler, NULL);
+	if (ret) {
+		printf("failed to start runtime\n");
+		return ret;
+	}
+
+	return 0;
+}

--- a/tests/test_udp.c
+++ b/tests/test_udp.c
@@ -1,0 +1,67 @@
+/*
+ * test_ping.c - sends ping echo requests
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <runtime/udp.h>
+#include <runtime/runtime.h>
+#include <runtime/timer.h>
+
+#define DEST_IP_ADDR 3232235778 // 192.168.1.2
+
+static void main_handler(void *arg)
+{
+    int err;
+    udpconnspawn_t *s;
+    udpconn_t *c;
+    char buf[16];
+    ssize_t read_len;
+    struct netaddr raddr;
+    struct netaddr laddr = { .ip = 0, .port = 4242 };
+
+    err = udp_conn_listen(laddr, 40, &s);
+    if (err) {
+        printf("Could not make udp listen\n");
+        return;
+    }
+
+    printf("listening\n");
+
+    err = udp_accept(s, &c);
+    if (err) {
+        printf("udp accept error\n");
+        return;
+    }
+
+    raddr = udp_remote_addr(c);
+    printf("got connection from %u:%u\n", raddr.ip, raddr.port);
+    read_len = udp_read_from(c, buf, 16, &raddr);
+    printf("[");
+    for (int i = 0 ; i < read_len ; i++) {
+        printf("%u, ", buf[i]);
+    }
+    printf("]\n");
+
+
+    printf("ok\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+
+	if (argc < 2) {
+		printf("arg must be config file\n");
+		return -EINVAL;
+	}
+
+	ret = runtime_init(argv[1], main_handler, NULL);
+	if (ret) {
+		printf("failed to start runtime\n");
+		return ret;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This PR adds rust bindings for:
- mutex
- poll
- condvars 
- non-basic timers

As well as the following features in the runtime:
- udp_accept (the udp version of tcp accept)
- IP loopback support

The rust bindings and runtime features can be separated into multiple PRs if that is desirable.