### PR TITLE
ksched: update PF hole from newer Linux kernel

### DIFF
--- a/ksched/ksched.c
+++ b/ksched/ksched.c
@@ -41,10 +41,10 @@
 #define CORE_PERF_GLOBAL_CTRL_ENABLE_PMC_1 (0x2)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6,1,0)
-#define PF__HOLE__00004000 0x00004000
+#define PF__HOLE__40000000 0x40000000
 #endif
 
-#define PF_KSCHED_PARKED PF__HOLE__00004000
+#define PF_KSCHED_PARKED PF__HOLE__40000000
 
 /* the character device that provides the ksched IOCTL interface */
 static struct cdev ksched_cdev;


### PR DESCRIPTION
`PF__HOLE__00004000` is removed in recent Linux kernels so using `PF__HOLE__40000000` now.

https://github.com/torvalds/linux/commit/fb04563d1cae6f361892b4a339ad92100b1eb0d0

https://github.com/torvalds/linux/commit/54e6842d0775ba76db65cbe21311c3ca466e663d#diff-f8d8a1568ae83bbff6f40f9c70559a4f7dbf426a397131ba9d4fbfb947ea5222