### PR TITLE
add config option for transparent hugepages

### DIFF
--- a/base/mem.c
+++ b/base/mem.c
@@ -27,6 +27,8 @@
 #warning "Your system does not support specifying SHM_HUGETLB page sizes"
 #endif
 
+bool cfg_transparent_hugepages_enabled = false;
+
 /* libc conflicts with linux/shm.h, so define these ourselves */
 void* shmat(int shm_id, const void *addr, int flags);
 int shmctl(int shm_id, int cmd, struct shmid_ds* buf);
@@ -73,24 +75,26 @@ __mem_map_anom(void *base, size_t len, size_t pgsize,
 	if (base)
 		flags |= MAP_FIXED;
 
-	switch (pgsize) {
-	case PGSIZE_4KB:
-		break;
-	case PGSIZE_2MB:
-		flags |= MAP_HUGETLB;
+	if (!cfg_transparent_hugepages_enabled) {
+	    switch (pgsize) {
+	    case PGSIZE_4KB:
+	        break;
+	    case PGSIZE_2MB:
+	        flags |= MAP_HUGETLB;
 #ifdef MAP_HUGE_2MB
-		flags |= MAP_HUGE_2MB;
+	        flags |= MAP_HUGE_2MB;
 #endif
-		break;
-	case PGSIZE_1GB:
+	        break;
+	    case PGSIZE_1GB:
 #ifdef MAP_HUGE_1GB
-		flags |= MAP_HUGETLB | MAP_HUGE_1GB;
+	        flags |= MAP_HUGETLB | MAP_HUGE_1GB;
 #else
-		return MAP_FAILED;
+	        return MAP_FAILED;
 #endif
-		break;
-	default: /* fail on other sizes */
-		return MAP_FAILED;
+	        break;
+	    default: /* fail on other sizes */
+	        return MAP_FAILED;
+	    }
 	}
 
 	addr = mmap(base, len, PROT_READ | PROT_WRITE, flags, -1, 0);
@@ -101,6 +105,11 @@ __mem_map_anom(void *base, size_t len, size_t pgsize,
 	if (mbind(addr, len, numa_policy, mask ? mask : NULL,
 		  mask ? NNUMA + 1 : 0, MPOL_MF_STRICT | MPOL_MF_MOVE))
 		goto fail;
+
+	if (cfg_transparent_hugepages_enabled && (flags & MAP_HUGETLB)) {
+	  if (madvise(addr, len, MADV_HUGEPAGE))
+	    goto fail;
+	}
 
 	touch_mapping(addr, len, pgsize);
 	return addr;

--- a/inc/base/mem.h
+++ b/inc/base/mem.h
@@ -18,6 +18,8 @@ enum {
 	PGSIZE_1GB = (1 << PGSHIFT_1GB), /* 1073741824 bytes */
 };
 
+extern bool cfg_transparent_hugepages_enabled;
+
 #define PGMASK_4KB	(PGSIZE_4KB - 1)
 #define PGMASK_2MB	(PGSIZE_2MB - 1)
 #define PGMASK_1GB	(PGSIZE_1GB - 1)

--- a/runtime/cfg.c
+++ b/runtime/cfg.c
@@ -11,6 +11,7 @@
 #include <base/bitmap.h>
 #include <base/log.h>
 #include <base/cpu.h>
+#include <base/mem.h>
 
 #include "defs.h"
 
@@ -357,6 +358,11 @@ static int parse_enable_gc(const char *name, const char *val)
 #endif
 }
 
+static int parse_enable_transparent_hugepages(const char *name, const char *val)
+{
+  cfg_transparent_hugepages_enabled = true;
+  return 0;
+}
 
 /*
  * Parsing Infrastructure
@@ -393,6 +399,7 @@ static const struct cfg_handler cfg_handlers[] = {
 	{ "enable_storage", parse_enable_storage, false },
 	{ "enable_directpath", parse_enable_directpath, false },
 	{ "enable_gc", parse_enable_gc, false },
+	{ "enable_transparent_hugepages", parse_enable_transparent_hugepages, false},
 
 };
 
@@ -504,13 +511,14 @@ int cfg_load(const char *path)
 		 cfg_prio_is_lc ? "latency critical (LC)" : "best effort (BE)");
 	log_info("cfg: THRESH_QD: %ld, THRESH_HT: %ld THRESH_QUANTUM: %ld",
 		 cfg_qdelay_us, cfg_ht_punish_us, cfg_quantum_us);
-	log_info("cfg: storage %s, directpath %s",
+	log_info("cfg: storage %s, directpath %s, transparent hugepages %s",
 #ifdef DIRECT_STORAGE
 		 cfg_storage_enabled ? "enabled" : "disabled",
 #else
 		"disabled",
 #endif
-		 cfg_directpath_enabled() ? "enabled" : "disabled");
+		 cfg_directpath_enabled() ? "enabled" : "disabled",
+		 cfg_transparent_hugepages_enabled ? "enabled" : "disabled");
 
 out:
 	fclose(f);

--- a/runtime/defs.h
+++ b/runtime/defs.h
@@ -617,6 +617,8 @@ enum {
 	DIRECTPATH_MODE_EXTERNAL,
 };
 
+extern bool cfg_transparent_hugepages_enabled;
+
 static inline bool is_directpath_strided(void)
 {
 	return cfg_directpath_strided;

--- a/scripts/setup_machine.sh
+++ b/scripts/setup_machine.sh
@@ -31,6 +31,8 @@ for n in /sys/devices/system/node/node*; do
 echo 5192 > ${n}/hugepages/hugepages-2048kB/nr_hugepages
 done
 
+echo madvise > /sys/kernel/mm/transparent_hugepage/enabled
+
 # load msr module
 modprobe msr
 


### PR DESCRIPTION
add `enable_transparent_hugepages` config option to avoid reserving hugepages for higher density at the cost of an extra syscall (`madvise`) for each mapping with page size > `PGSIZE_4KB`