### PR TITLE
iokernel bug fix: also initialize mbp_priv.flags on tx side.

### DIFF
--- a/iokernel/tx.c
+++ b/iokernel/tx.c
@@ -339,7 +339,7 @@ static struct rte_mempool *tx_pktmbuf_completion_pool_create(const char *name,
 		unsigned n, uint16_t priv_size, int socket_id)
 {
 	struct rte_mempool *mp;
-	struct rte_pktmbuf_pool_private mbp_priv;
+	struct rte_pktmbuf_pool_private mbp_priv = {0};
 	unsigned elt_size;
 	int ret;
 


### PR DESCRIPTION
This PR adds the missing initialization of `mbp_priv` in the IOKernel when initializing the tx mempool. This is the same as the fix on rx side: https://github.com/shenango/caladan/commit/0e686a8c4853188e1778eb4e2f7953217b13ad8d.

Without this fix when sending packets on a MLX5 NIC I saw the DPDK `oerror` counter increasing, and `Unexpected CQE error syndrome 0x04 CQN = 128 SQN = 14688 wqe_counter = 1 wq_ci = 2 cq_ci = 0` reported in dpdk log files in `/var/log/`. Looks like `mbp_priv.flags` is used (only?) in the MLX5 driver (e.g., https://github.com/DPDK/dpdk/blob/eeb0605f118dae66e80faa44f7b3e88748032353/drivers/net/mlx5/mlx5_trigger.c#L134), which might be the root cause.