### PR TITLE
net: fix tcp window scaling in SYN-ACK handshake

### DIFF
--- a/runtime/net/tcp_in.c
+++ b/runtime/net/tcp_in.c
@@ -403,6 +403,9 @@ __tcp_rx_conn(tcpconn_t *c, struct mbuf *m, uint32_t ack, uint32_t snd_nxt,
 			opts.mss = c->pcb.rcv_mss;
 			opts.wscale = c->pcb.rcv_wscale;
 
+			/* scale the window now that we know the wscale */
+			win <<= c->pcb.snd_wscale;
+
 			if ((m->flags & TCP_ACK) > 0) {
 				c->pcb.snd_una = ack;
 				tcp_conn_ack(c, &q);


### PR DESCRIPTION
Apply the window scale factor to the sender window immediately
after the three-way handshake completes on the connection initiator.

Previously, the window scale factor was not applied to the send window
until the next ACK arrived. As a result, the sender temporarily
underestimated the available send window immediately after connection
establishment.

This caused problems for senders that wait for the full send window to
be available before transmitting data, such as when loadgen issues
large non-partial writes (e.g., 1MB). In these cases, no data could be
sent, preventing the ACK that would have corrected the window size.