### PR TITLE
tcp: skip zero-length iovecs in tcp_writev2

### DIFF
--- a/runtime/net/tcp.c
+++ b/runtime/net/tcp.c
@@ -1405,6 +1405,8 @@ ssize_t tcp_writev2(tcpconn_t *c, const struct iovec *iov, int iovcnt,
 	for (i = 0; i < iovcnt; i++, iov++) {
 		if (winlen <= 0)
 			break;
+		if (!iov->iov_len)
+			continue;
 		ret = tcp_tx_send(c, iov->iov_base, MIN(iov->iov_len, winlen),
 		                  i == iovcnt - 1 && iov->iov_len <= winlen);
 		if (ret <= 0)


### PR DESCRIPTION
This commit fixes a bug with tcp_writev2.

Applications, such as memcached, can pass iovecs with zero length into tcp_writev2. Then, the main writev loop passes these entries to tcp_tx_send(). If an early entry is zero-length, tcp_tx_send() returns 0 and tcp_writev2() breaks early instead of continuing to later non-empty iovecs.

This can cause applications to get stuck retrying sendmsg's that never make progress.

Skip iovecs with iov_len == 0 before calling tcp_tx_send(). This avoids premature termination of the main writev loop